### PR TITLE
Add loose mode to babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,5 @@
 {
   "stage": 0,
+  "loose": "all",
   "optional": "runtime"
 }


### PR DESCRIPTION
Copies react-router, and makes usage in old IE less error-prone.

https://babeljs.io/docs/advanced/caveats/#internet-explorer
https://github.com/rackt/react-router/blob/master/.babelrc

Might be enough to just set loose on modules and classes, as those are the ones mentioned explicitly, but copying react-router should be fine :smile: 
