### PR TITLE
Make babel-runtime a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "babel-core": "^5.8.25",
     "babel-eslint": "^4.1.3",
     "babel-loader": "^5.1.2",
-    "babel-runtime": "^5.8.24",
     "chai": "^3.2.0",
     "eslint": "^1.5.0",
     "eslint-loader": "^1.0.0",
@@ -58,6 +57,7 @@
     "react": ">=0.13.0"
   },
   "dependencies": {
+    "babel-runtime": "^5.8.24",
     "lodash.debounce": "^3.1.1",
     "object-assign": "^4.0.1"
   }


### PR DESCRIPTION
Since you use Babel's [runtime](https://github.com/alexkuz/react-dock/blob/master/.babelrc#L4) option, `babel-runtime` needs to be a dependency rather than a devDependency. (Notice all the `require('babel-runtime/...')` calls in `lib/`.)

Currently, `react-dock` only works if another package coincidentally already has `babel-runtime` installed as a dependency.
