### PR TITLE
Fix: update to babel 6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,4 @@
 {
-  "stage": 0,
-  "loose": "all",
-  "optional": "runtime"
+  "presets": ["es2015", "stage-0", "react"],
+  "plugins": ["transform-runtime"]
 }

--- a/package.json
+++ b/package.json
@@ -32,33 +32,37 @@
   },
   "homepage": "https://github.com/alexkuz/react-dock",
   "devDependencies": {
-    "babel": "^5.8.23",
-    "babel-core": "^5.8.25",
-    "babel-eslint": "^4.1.3",
-    "babel-loader": "^5.1.2",
-    "chai": "^3.2.0",
-    "eslint": "^1.5.0",
-    "eslint-loader": "^1.0.0",
-    "eslint-plugin-babel": "^2.1.1",
-    "eslint-plugin-react": "^3.4.2",
-    "imports-loader": "^0.6.4",
-    "json-loader": "^0.5.2",
-    "mocha": "^2.3.2",
-    "radium": "^0.14.3",
+    "babel": "^6.3.13",
+    "babel-cli": "^6.3.17",
+    "babel-core": "^6.3.17",
+    "babel-eslint": "^5.0.0-beta6",
+    "babel-loader": "^6.2.0",
+    "babel-plugin-transform-runtime": "^6.3.13",
+    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-react": "^6.3.13",
+    "babel-preset-stage-0": "^6.3.13",
+    "chai": "^3.4.1",
+    "eslint": "^1.10.3",
+    "eslint-loader": "^1.1.1",
+    "eslint-plugin-babel": "^3.0.0",
+    "eslint-plugin-react": "^3.11.3",
+    "imports-loader": "^0.6.5",
+    "json-loader": "^0.5.4",
+    "mocha": "^2.3.4",
+    "radium": "^0.15.3",
     "raw-loader": "^0.5.1",
-    "react-bootstrap": "^0.27.3",
-    "react-dom": "^0.14.0",
-    "react-hot-loader": "^1.2.8",
+    "react-bootstrap": "^0.28.1",
+    "react-dom": "^0.14.3",
+    "react-hot-loader": "^1.3.0",
     "react-pure-render": "^1.0.2",
-    "webpack": "^1.12.2",
-    "webpack-dev-server": "^1.11.0"
+    "webpack": "^1.12.9",
+    "webpack-dev-server": "^1.14.0"
   },
   "peerDependencies": {
-    "react": ">=0.13.0"
+    "react": ">=0.13.0",
+    "babel-runtime": "^6.3.13"
   },
   "dependencies": {
-    "babel-runtime": "^5.8.24",
-    "lodash.debounce": "^3.1.1",
-    "object-assign": "^4.0.1"
+    "lodash.debounce": "^3.1.1"
   }
 }

--- a/src/Dock.js
+++ b/src/Dock.js
@@ -1,6 +1,5 @@
 import React, { Component, PropTypes } from 'react';
 import debounce from 'lodash.debounce';
-import assign from 'object-assign';
 import autoprefix from './autoprefix';
 
 function autoprefixes(styles) {
@@ -319,12 +318,12 @@ export default class Dock extends Component {
     const { children, zIndex, dimMode, position, isVisible } = this.props;
     const { isResizing, size, isDimHidden } = this.state;
 
-    const dimStyles = assign({}, ...getDimStyles(this.props, this.state));
-    const dockStyles = assign({}, ...getDockStyles(this.props, this.state));
-    const resizerStyles = assign({}, ...getResizerStyles(position));
+    const dimStyles = Object.assign({}, ...getDimStyles(this.props, this.state));
+    const dockStyles = Object.assign({}, ...getDockStyles(this.props, this.state));
+    const resizerStyles = Object.assign({}, ...getResizerStyles(position));
 
     return (
-      <div style={assign({}, styles.wrapper, { zIndex })}>
+      <div style={Object.assign({}, styles.wrapper, { zIndex })}>
         {dimMode !== 'none' && !isDimHidden &&
           <div style={dimStyles} onClick={this.handleDimClick} />
         }


### PR DESCRIPTION
The current build on `npm` is not working with projects with Babel 6.x.
- [x] update to Babel 6
- [x] use `Object.assign` instead of  `object-assign`
