### PR TITLE
Allow to disable resizing functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ render() {
 | size | Size of dock panel (width or height, depending on `position`). If this prop is set, `Dock` is considered as a controlled component, so you need to use `onSizeChange` to track dock resizing. Value is a fraction of window width/height, if `fluid` is true, or pixels otherwise |
 | defaultSize | Default size of dock panel (used for uncontrolled `Dock` component) |
 | isVisible | If `true`, dock is visible |
+| isResizable | If `false`, then resizing is disabled |
 | dimMode | If `none` - content is not dimmed, if `transparent` - pointer events are disabled (so you can click through it), if `opaque` - click on dim area closes the dock. Default is `opaque` |
 | duration | Animation duration. Should be synced with transition animation in style properties |
 | dimStyle | Style for dim area |

--- a/src/Dock.js
+++ b/src/Dock.js
@@ -232,6 +232,7 @@ export default class Dock extends Component {
     defaultSize: PropTypes.number,
     dimMode: PropTypes.oneOf(['none', 'transparent', 'opaque']),
     isVisible: PropTypes.bool,
+    isResizable: PropTypes.bool,
     onVisibleChange: PropTypes.func,
     onSizeChange: PropTypes.func,
     dimStyle: PropTypes.object,
@@ -245,7 +246,8 @@ export default class Dock extends Component {
     fluid: true,
     defaultSize: 0.3,
     dimMode: 'opaque',
-    duration: 200
+    duration: 200,
+    isResizable: true
   }
 
   componentDidMount() {
@@ -315,7 +317,7 @@ export default class Dock extends Component {
   }
 
   render() {
-    const { children, zIndex, dimMode, position, isVisible } = this.props;
+    const { children, zIndex, dimMode, position, isVisible, isResizable } = this.props;
     const { isResizing, size, isDimHidden } = this.state;
 
     const dimStyles = Object.assign({}, ...getDimStyles(this.props, this.state));
@@ -328,8 +330,12 @@ export default class Dock extends Component {
           <div style={dimStyles} onClick={this.handleDimClick} />
         }
         <div style={dockStyles}>
-          <div style={resizerStyles}
-               onMouseDown={this.handleMouseDown} />
+          {isResizable &&
+            <div
+              style={resizerStyles}
+              onMouseDown={this.handleMouseDown}
+            />
+          }
           <div style={styles.dockContent}>
             {typeof children === 'function' ?
               children({


### PR DESCRIPTION
Pass `isResizable` to control ability to resize the panel. (`true` by default for ensuring backwards compatability)