### PR TITLE
Add TypeScript declaration for Dock

### DIFF
--- a/src/Dock.d.ts
+++ b/src/Dock.d.ts
@@ -1,0 +1,7 @@
+declare module "react-dock" {
+  import PropTypes, { InferProps } from "prop-types";
+  import Dock from "./Dock";
+
+  type DockProps = InferProps<typeof Dock.propTypes, typeof Dock.defaultPropTypes>;
+  export default class Dock extends React.Component<DockProps, any> {}
+}


### PR DESCRIPTION
Currently, attempting to use this module in TypeScript returns an error because there is no type declaration. Thankfully, the `prop-types` library makes it really easy to generate the type declaration from Dock's proptypes.